### PR TITLE
Enforce ssl

### DIFF
--- a/db.tf
+++ b/db.tf
@@ -13,6 +13,7 @@ resource "aws_db_instance" "this" {
   port                   = local.port
   vpc_security_group_ids = [aws_security_group.this.id]
   tags                   = local.tags
+  publicly_accessible    = var.enable_public_access
 
   username = replace(data.ns_workspace.this.block_ref, "-", "_")
   password = random_password.this.result

--- a/security-groups.tf
+++ b/security-groups.tf
@@ -27,3 +27,14 @@ resource "aws_security_group_rule" "user-to-this" {
   to_port                  = local.port
   source_security_group_id = aws_security_group.this.id
 }
+
+resource "aws_security_group_rule" "this-from-world" {
+  security_group_id = aws_security_group.this.id
+  protocol          = "tcp"
+  type              = "ingress"
+  from_port         = local.port
+  to_port           = local.port
+  cidr_blocks       = ["0.0.0.0/0"]
+
+  count = var.enable_public_access ? 1 : 0
+}

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,16 @@ This is highly recommended if you have public access enabled.
 EOF
 }
 
+variable "enable_public_access" {
+  type        = bool
+  default     = false
+  description = <<EOF
+By default, the postgres cluster is not accessible to the public.
+If you want to access your database, we recommend using a bastion instead.
+However, this is necessary for scenarios like connecting from a Heroku app.
+EOF
+}
+
 locals {
   port = 5432
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,16 @@ In dev environments, it is best to turn off to save on costs.
 EOF
 }
 
+variable "enforce_ssl" {
+  type        = bool
+  default     = false
+  description = <<EOF
+By default, the postgres cluster will have SSL enabled.
+This toggle will require an SSL connection.
+This is highly recommended if you have public access enabled.
+EOF
+}
+
 locals {
   port = 5432
 }


### PR DESCRIPTION
This PR enables users to connect the postgres cluster to heroku.
This is done by enabling a new variable `enable_public_access` and enabling `enforce_ssl`.