### PR TITLE
Prevent destruction of db when postgres version changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ envs/
 .nullstone.json
 .terraform.lock.hcl
 __backend__.tf
+.nullstone/active-workspace.yml

--- a/.nullstone/module.yml
+++ b/.nullstone/module.yml
@@ -1,0 +1,11 @@
+org_name: nullstone
+name: aws-rds-postgres
+friendly_name: RDS Postgres Cluster
+description: Produces a standard, best-practice RDS Postgres cluster in AWS
+category: datastore
+type: postgres/aws
+appCategories: []
+layer: database
+is_public: true
+provider_types:
+    - aws

--- a/db.tf
+++ b/db.tf
@@ -44,7 +44,7 @@ locals {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name_prefix = local.block_name
+  name        = "${local.resource_name}-${var.postgres_version}"
   family      = "postgres${var.postgres_version}"
   tags        = local.tags
   description = "Postgres for ${local.block_name} (${local.env_name})"

--- a/db.tf
+++ b/db.tf
@@ -44,9 +44,10 @@ locals {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name   = local.resource_name
-  family = "postgres${var.postgres_version}"
-  tags   = local.tags
+  name        = local.resource_name
+  family      = "postgres-${local.resource_name}"
+  tags        = local.tags
+  description = "Postgres for ${local.block_name} (${local.env_name})"
 
   dynamic "parameter" {
     for_each = local.db_parameters

--- a/db.tf
+++ b/db.tf
@@ -44,7 +44,7 @@ locals {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name        = "${local.resource_name}-${var.postgres_version}"
+  name        = "${local.resource_name}-postgres${var.postgres_version}"
   family      = "postgres${var.postgres_version}"
   tags        = local.tags
   description = "Postgres for ${local.block_name} (${local.env_name})"

--- a/db.tf
+++ b/db.tf
@@ -44,10 +44,16 @@ locals {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name        = local.resource_name
-  family      = "postgres-${local.resource_name}"
+  name_prefix = local.block_name
+  family      = "postgres${var.postgres_version}"
   tags        = local.tags
   description = "Postgres for ${local.block_name} (${local.env_name})"
+
+  // When postgres version changes, we need to create a new one that attaches to the db
+  //   because we can't destroy a parameter group that's in use
+  lifecycle {
+    create_before_destroy = true
+  }
 
   dynamic "parameter" {
     for_each = local.db_parameters

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -6,6 +6,9 @@ terraform {
   }
 }
 
+data "ns_workspace" "this" {}
+
+// Generate a random suffix to ensure uniqueness of resources
 resource "random_string" "resource_suffix" {
   length  = 5
   lower   = true
@@ -14,7 +17,12 @@ resource "random_string" "resource_suffix" {
   special = false
 }
 
-data "ns_workspace" "this" {}
+locals {
+  tags               = data.ns_workspace.this.tags
+  block_name         = data.ns_workspace.this.block_name
+  resource_name      = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
+}
+
 
 data "ns_connection" "network" {
   name = "network"
@@ -22,10 +30,7 @@ data "ns_connection" "network" {
 }
 
 locals {
-  resource_name      = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
-  block_name         = data.ns_workspace.this.block_name
   env_name           = data.ns_workspace.this.env_name
-  tags               = data.ns_workspace.this.tags
   vpc_id             = data.ns_connection.network.outputs.vpc_id
   public_subnet_ids  = data.ns_connection.network.outputs.public_subnet_ids
   private_subnet_ids = data.ns_connection.network.outputs.private_subnet_ids

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -23,6 +23,8 @@ data "ns_connection" "network" {
 
 locals {
   resource_name      = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
+  block_name         = data.ns_workspace.this.block_name
+  env_name           = data.ns_workspace.this.env_name
   tags               = data.ns_workspace.this.tags
   vpc_id             = data.ns_connection.network.outputs.vpc_id
   public_subnet_ids  = data.ns_connection.network.outputs.public_subnet_ids


### PR DESCRIPTION
The db parameter group was tied to postgres version via `family`.
When `family` changes, the db parameter group is forced to recreate.
This is unnecessary and creates a failed plan because the db parameter group is in use.