### PR TITLE
B1687 cant update params

### DIFF
--- a/db-params.tf
+++ b/db-params.tf
@@ -10,7 +10,7 @@ locals {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name        = local.param_group_name
+  name_prefix = local.param_group_name
   family      = "postgres${var.postgres_version}"
   tags        = local.tags
   description = "Postgres for ${local.block_name} (${local.env_name})"


### PR DESCRIPTION
Use the name-prefix instead of name so that we dont have any issues when making changes.

I recreated the exact issue Glass is having in my own environment. The following screenshot is the plan that gets executed with this change in place. It ran through with no problem.

![Screenshot 2023-09-07 at 2 06 46 PM](https://github.com/nullstone-modules/aws-rds-postgres/assets/771008/7a6d011c-a6b9-47c1-b5a3-91237d346fbd)
