### PR TITLE
Added metrics support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.2 (Feb 06, 2024)
+* Added metrics support.
+
 # 0.13.1 (Oct 24, 2023)
 * Added description (with link to available choices) to `instance_class`.
 

--- a/aws.tf
+++ b/aws.tf
@@ -1,2 +1,6 @@
 data "aws_region" "this" {}
 data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}

--- a/logs.tf
+++ b/logs.tf
@@ -11,3 +11,51 @@ resource "aws_cloudwatch_log_group" "upgrade" {
   kms_key_id        = aws_kms_key.this.arn
   tags              = local.tags
 }
+
+resource "aws_iam_user" "log_reader" {
+  name = "log-reader-${local.resource_name}"
+  tags = local.tags
+}
+
+resource "aws_iam_access_key" "log_reader" {
+  user = aws_iam_user.log_reader.name
+}
+
+resource "aws_iam_user_policy" "log_reader" {
+  name   = "AllowReadLogsAndMetrics"
+  user   = aws_iam_user.log_reader.name
+  policy = data.aws_iam_policy_document.log_reader.json
+}
+
+data "aws_iam_policy_document" "log_reader" {
+  statement {
+    sid    = "AllowReadLogs"
+    effect = "Allow"
+
+    actions = [
+      "logs:Get*",
+      "logs:List*",
+      "logs:StartQuery",
+      "logs:StopQuery",
+      "logs:TestMetricFilter",
+      "logs:Filter*"
+    ]
+
+    resources = [
+      aws_cloudwatch_log_group.this.arn,
+      aws_cloudwatch_log_group.upgrade.arn,
+    ]
+  }
+
+  statement {
+    sid       = "AllowGetMetrics"
+    effect    = "Allow"
+    resources = ["*"] // Metrics cannot be restricted by resource
+
+    actions = [
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+    ]
+  }
+}

--- a/metrics.tf
+++ b/metrics.tf
@@ -1,0 +1,73 @@
+locals {
+  dims = tomap({
+    "DBInstanceIdentifier" = aws_db_instance.this.identifier
+  })
+
+  metrics_mappings = [
+    {
+      name = "cpu"
+      type = "usage-percent"
+      unit = "%"
+
+      mappings = {
+        cpu_average = {
+          account_id  = local.account_id
+          stat        = "Average"
+          namespace   = "AWS/RDS"
+          metric_name = "CPUUtilization"
+          dimensions  = local.dims
+        }
+        cpu_min = {
+          account_id  = local.account_id
+          stat        = "Minimum"
+          namespace   = "AWS/RDS"
+          metric_name = "CPUUtilization"
+          dimensions  = local.dims
+        }
+        cpu_max = {
+          account_id  = local.account_id
+          stat        = "Maximum"
+          namespace   = "AWS/RDS"
+          metric_name = "CPUUtilization"
+          dimensions  = local.dims
+        }
+      }
+    },
+    {
+      name = "memory"
+      type = "usage"
+      unit = "MB"
+
+      mappings = {
+        memory_average = {
+          account_id  = local.account_id
+          expression  = "memory_average_bytes / 1048576" // Convert bytes to MB
+          dimensions  = local.dims
+        }
+        memory_average_bytes = {
+          account_id        = local.account_id
+          stat              = "Average"
+          namespace         = "AWS/RDS"
+          metric_name       = "FreeableMemory"
+          dimensions        = local.dims
+          hide_from_results = true
+        }
+      }
+    },
+    {
+      name = "connections"
+      type = "generic"
+      unit = "count"
+
+      mappings = {
+        connections_total = {
+          account_id  = local.account_id
+          stat        = "Average"
+          namespace   = "AWS/RDS"
+          metric_name = "DatabaseConnections"
+          dimensions  = local.dims
+        }
+      }
+    }
+  ]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "region" {
+  value       = data.aws_region.this.name
+  description = "string ||| The AWS Region that this instance is deployed"
+}
+
 output "db_instance_arn" {
   value       = aws_db_instance.this.arn
   description = "string ||| ARN of the Postgres instance"
@@ -52,4 +57,23 @@ output "db_log_group" {
 output "db_upgrade_log_group" {
   value       = aws_cloudwatch_log_group.upgrade.name
   description = "string ||| The name of the Cloudwatch Log Group where upgrade logs are emitted for the DB Instance"
+}
+
+output "metrics_provider" {
+  value       = "cloudwatch"
+  description = "string ||| "
+}
+
+output "metrics_reader" {
+  value = {
+    name       = aws_iam_user.log_reader.name
+    access_key = aws_iam_access_key.log_reader.id
+    secret_key = aws_iam_access_key.log_reader.secret
+  }
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to read metrics from Cloudwatch."
+  sensitive   = true
+}
+
+output "metrics_mappings" {
+  value = local.metrics_mappings
 }


### PR DESCRIPTION
This adds the necessary mappings and metrics reader to add metrics to the UI for RDS Postgres.

This is the first of many PRs to enable these metrics:
- Existing RDS Postgres
- RDS MySQL 
- Existing RDS MySQL